### PR TITLE
Support text 2

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,27 +1,7 @@
 packages: ./country, ./code-generation
 
-allow-newer:
-    zigzag:base,
-    haskell-src-meta:template-haskell,
-    siphon:text,
-    disjoint-containers:aeson,
-    colonnade:bytestring,
-    colonnade:text,
-
 -- https://github.com/byteverse/bytebuild/pull/29
 source-repository-package
     type: git
     location: https://github.com/parsonsmatt/bytebuild
     tag: f65821b505233a98e74786d7c7ec66aabae50a61
-
--- https://github.com/erikd/wide-word/pull/69
-source-repository-package
-    type: git
-    location: https://github.com/parsonsmatt/wide-word
-    tag: 4d91acc4e3c0880d2d399d8adc337395df2b6026
-
--- https://github.com/haskell-primitive/primitive-unaligned/pull/10
-source-repository-package
-    type: git
-    location: https://github.com/parsonsmatt/primitive-unaligned
-    tag: 25a9ec03577e979671496ba9c8af58fbe952f3fc

--- a/cabal.project
+++ b/cabal.project
@@ -8,9 +8,6 @@ allow-newer:
     colonnade:bytestring,
     colonnade:text,
 
-constraints:
-    text < 2
-
 -- https://github.com/byteverse/bytebuild/pull/29
 source-repository-package
     type: git

--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,27 @@
 packages: ./country, ./code-generation
+
+allow-newer:
+    zigzag:base,
+    haskell-src-meta:template-haskell,
+    siphon:text,
+    disjoint-containers:aeson,
+    colonnade:bytestring,
+    colonnade:text,
+
+-- https://github.com/byteverse/bytebuild/pull/29
+source-repository-package
+    type: git
+    location: https://github.com/parsonsmatt/bytebuild
+    tag: e8dee26a4cc379a1971b428187fad51824de8e38
+
+-- https://github.com/erikd/wide-word/pull/69
+source-repository-package
+    type: git
+    location: https://github.com/parsonsmatt/wide-word
+    tag: 8d8447cda8b6410c262408f605d0679623367071
+
+-- https://github.com/haskell-primitive/primitive-unaligned/pull/10
+source-repository-package
+    type: git
+    location: https://github.com/parsonsmatt/primitive-unaligned
+    tag: 25a9ec03577e979671496ba9c8af58fbe952f3fc

--- a/cabal.project
+++ b/cabal.project
@@ -9,7 +9,7 @@ allow-newer:
     colonnade:text,
 
 constraints:
-    text == 2.0.1
+    text < 2
 
 -- https://github.com/byteverse/bytebuild/pull/29
 source-repository-package

--- a/cabal.project
+++ b/cabal.project
@@ -8,17 +8,20 @@ allow-newer:
     colonnade:bytestring,
     colonnade:text,
 
+constraints:
+    text == 2.0.1
+
 -- https://github.com/byteverse/bytebuild/pull/29
 source-repository-package
     type: git
     location: https://github.com/parsonsmatt/bytebuild
-    tag: e8dee26a4cc379a1971b428187fad51824de8e38
+    tag: f65821b505233a98e74786d7c7ec66aabae50a61
 
 -- https://github.com/erikd/wide-word/pull/69
 source-repository-package
     type: git
     location: https://github.com/parsonsmatt/wide-word
-    tag: 8d8447cda8b6410c262408f605d0679623367071
+    tag: 4d91acc4e3c0880d2d399d8adc337395df2b6026
 
 -- https://github.com/haskell-primitive/primitive-unaligned/pull/10
 source-repository-package

--- a/country/country.cabal
+++ b/country/country.cabal
@@ -75,7 +75,7 @@ library
     , primitive >= 0.6.4 && <0.8
     , primitive-unlifted >= 0.1.3 && <1.0
     , scientific >=0.3 && <0.4
-    , text >= 1.2 && <1.3
+    , text >= 1.2 && <2.2
     , text-short >=0.1.3
     , unordered-containers >=0.2 && <0.3
   default-language: Haskell2010

--- a/country/src/Continent.hs
+++ b/country/src/Continent.hs
@@ -26,7 +26,7 @@ import Continent.Unsafe
 import Control.Monad (forM_)
 import Control.Monad.ST (runST)
 import Country.Unexposed.Continents (continentAList)
-import Country.Unexposed.Util (mapTextArray,charToWord16,word16ToInt,timesTwo)
+import Country.Unexposed.Util (mapTextArray,word16ToInt,timesTwo,charToTextWord)
 import Country.Unsafe (Country(Country))
 import Data.Char (toLower)
 import Data.Text (Text)
@@ -51,8 +51,8 @@ allAlphaUpper = TA.run $ do
   m <- TA.new (timesTwo numberOfContinents)
   forM_ continentNameDb $ \(n,_,(a1,a2)) -> do
     let ix = timesTwo (fromIntegral n)
-    TA.unsafeWrite m ix (charToWord16 a1)
-    TA.unsafeWrite m (ix + 1) (charToWord16 a2)
+    TA.unsafeWrite m ix (charToTextWord a1)
+    TA.unsafeWrite m (ix + 1) (charToTextWord a2)
   return m
 {-# NOINLINE allAlphaUpper #-}
 

--- a/country/src/Country.hs
+++ b/country/src/Country.hs
@@ -115,7 +115,7 @@ decodeAlphaThree = flip HM.lookup alphaThreeHashMap
 --   countries. It strives to handle any source language. Open an
 --   issue on the issue tracker if there are names that are missing.
 decode :: Text -> Maybe Country
-#if MIN_VERSION_base(4,17,0)
+#if MIN_VERSION_text(2,0,0)
 decode txt =
     decodeUtf8 (TE.encodeUtf8 txt)
 #else

--- a/country/src/Country.hs
+++ b/country/src/Country.hs
@@ -116,13 +116,14 @@ decodeAlphaThree = flip HM.lookup alphaThreeHashMap
 --   issue on the issue tracker if there are names that are missing.
 decode :: Text -> Maybe Country
 #if MIN_VERSION_base(4,17,0)
-decode (TI.Text (TA.ByteArray arr) off16 len16) =
+decode txt =
+    decodeUtf8 (TE.encodeUtf8 txt)
 #else
 decode (TI.Text (TA.Array arr) off16 len16) =
-#endif
   case (BytesHashMap.lookup (Bytes (ByteArray arr) (off16 * 2) (len16 * 2)) hashMapUtf16) of
     Nothing -> Nothing
     Just w -> Just (Country (fromIntegral w))
+#endif
 
 -- | Decode a 'Country' from a UTF-8-encoded 'ByteString'.
 decodeUtf8 :: ByteString -> Maybe Country

--- a/country/src/Country/Unexposed/Names.hs
+++ b/country/src/Country/Unexposed/Names.hs
@@ -1,3 +1,4 @@
+{-# language CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE MagicHash #-}
@@ -140,7 +141,11 @@ hashMapUtf8 = BytesHashMap.fromTrustedList
 hashMapUtf16 :: BytesHashMap.Map
 hashMapUtf16 = BytesHashMap.fromTrustedList
   ( map
+#if MIN_VERSION_base(4,17,0)
+    (\(a,Text.Text (Text.ByteArray arr) off16 len16) ->
+#else
     (\(a,Text.Text (Text.Array arr) off16 len16) ->
+#endif
       (Bytes (ByteArray arr) (off16 * 2) (len16 * 2),fromIntegral a)
     ) countryPairs
   )

--- a/country/src/Country/Unexposed/Names.hs
+++ b/country/src/Country/Unexposed/Names.hs
@@ -141,7 +141,7 @@ hashMapUtf8 = BytesHashMap.fromTrustedList
 hashMapUtf16 :: BytesHashMap.Map
 hashMapUtf16 = BytesHashMap.fromTrustedList
   ( map
-#if MIN_VERSION_base(4,17,0)
+#if MIN_VERSION_text(2,0,0)
     (\(a,Text.Text (Text.ByteArray arr) off16 len16) ->
 #else
     (\(a,Text.Text (Text.Array arr) off16 len16) ->

--- a/country/src/Country/Unexposed/Trie.hs
+++ b/country/src/Country/Unexposed/Trie.hs
@@ -14,8 +14,8 @@ import qualified Data.HashMap.Strict as HM
 import qualified Data.Attoparsec.Text as AT
 import qualified Data.Semigroup as SG
 
--- | If the value is not the max Word16 (65535), there 
---   is a match. This means that 65535 cannot be used, which 
+-- | If the value is not the max Word16 (65535), there
+--   is a match. This means that 65535 cannot be used, which
 --   is fine for this since 65535 is not used as a country code.
 data Trie = Trie
   { trieValue :: {-# UNPACK #-} !Word16

--- a/country/src/Country/Unexposed/Util.hs
+++ b/country/src/Country/Unexposed/Util.hs
@@ -31,7 +31,7 @@ import qualified Data.Text.Array as TA
 
 
 mapTextArray :: (Char -> Char) -> TA.Array -> TA.Array
-#if MIN_VERSION_base(4,17,0)
+#if MIN_VERSION_text(2,0,0)
 mapTextArray f src@(TA.ByteArray arr) = runST $ do
     -- this implementation is lifted from the text internals
       marr <- TA.new (l + 4)

--- a/country/src/Country/Unexposed/Util.hs
+++ b/country/src/Country/Unexposed/Util.hs
@@ -59,7 +59,7 @@ mapTextArray f src@(TA.ByteArray arr) = runST $ do
 mapTextArray f a@(TA.Array inner) = TA.run $ do
   let len = half (I# (sizeofByteArray# inner))
   m <- TA.new len
-  TA.copyI len m 0 a 0
+  TA.copyI m 0 a 0 len
   let go !ix = if ix < len
         then do
           TA.unsafeWrite m ix (charToTextWord (f (textWordToChar (TA.unsafeIndex a ix))))

--- a/country/src/Country/Unexposed/Util.hs
+++ b/country/src/Country/Unexposed/Util.hs
@@ -33,6 +33,7 @@ import qualified Data.Text.Array as TA
 mapTextArray :: (Char -> Char) -> TA.Array -> TA.Array
 #if MIN_VERSION_base(4,17,0)
 mapTextArray f src@(TA.ByteArray arr) = runST $ do
+    -- this implementation is lifted from the text internals
       marr <- TA.new (l + 4)
       outer marr (l + 4) o 0
       where


### PR DESCRIPTION
This PR adds support for `base-4.17` and `text-2`.

It's currently broken, most likely due to the dodgy word conversions.