### PR TITLE
Fix recursive Semigroup instance for Country.Unexposed.Trie

### DIFF
--- a/country/src/Country/Unexposed/Trie.hs
+++ b/country/src/Country/Unexposed/Trie.hs
@@ -39,7 +39,7 @@ singleton fullName code = go fullName where
     Nothing -> Trie code HM.empty
 
 instance Semigroup Trie where
-  (<>) = mappend
+  (<>) = append
 
 instance Monoid Trie where
   mempty = empty


### PR DESCRIPTION
This fixes a typo in 0b79a1311ebaa07a9be47b01b16d5f6f73147ab9.