### PR TITLE
build with primitive 0.8

### DIFF
--- a/country/country.cabal
+++ b/country/country.cabal
@@ -72,8 +72,8 @@ library
     , deepseq >= 1.3.0.2 && <1.5
     , entropy >=0.4.1.5 && <0.5
     , hashable >=1.2 && <1.5
-    , primitive >= 0.6.4 && <0.8
-    , primitive-unlifted >= 0.1.3 && <1.0
+    , primitive >= 0.6.4 && <0.9
+    , primitive-unlifted >= 0.1.3 && <1.4
     , scientific >=0.3 && <0.4
     , text >= 2.0 && <2.1
     , text-short >=0.1.3


### PR DESCRIPTION
```
❯ cabal build country --constraint="primitive == 0.8.0.0" --allow-newer=primitive-unaligned:primitive --allow-newer=primitive-unlifted:primitive --allow-newer=wide-word:primitive --allow-newer=bytebuild:primitive --allow-newer=byte-order:primitive --allow-newer=bytehash:primitive --allow-newer=aeson:primitive --allow-newer=contiguous:primitive --allow-newer=run-st:primitive --allow-newer=byteslice:primitive --allow-newer=tuples:primitive --allow-newer=primitive-addr:primitive
Resolving dependencies...
Build profile: -w ghc-9.4.4 -O1
In order, the following will be built (use -v for more details):
 - bytehash-0.1.0.0 (lib) (requires build)
 - transformers-compat-0.6.6 (lib) (requires build)
 - comonad-5.0.8 (lib) (requires build)
 - bifunctors-5.5.14 (lib) (requires build)
 - semigroupoids-5.3.7 (lib) (requires build)
 - assoc-1.0.2 (lib) (requires build)
 - these-1.1.1.1 (lib) (requires build)
 - strict-0.4.0.1 (lib) (requires build)
 - semialign-1.2.0.1 (lib) (requires build)
 - aeson-2.1.1.0 (lib) (requires build)
 - country-0.2.3.1 (lib) (first run)
Starting     bytehash-0.1.0.0 (lib)
Starting     transformers-compat-0.6.6 (lib)
Building     transformers-compat-0.6.6 (lib)
Building     bytehash-0.1.0.0 (lib)
Installing   transformers-compat-0.6.6 (lib)
Completed    transformers-compat-0.6.6 (lib)
Starting     comonad-5.0.8 (lib)
Installing   bytehash-0.1.0.0 (lib)
Completed    bytehash-0.1.0.0 (lib)
Building     comonad-5.0.8 (lib)
Installing   comonad-5.0.8 (lib)
Completed    comonad-5.0.8 (lib)
Starting     bifunctors-5.5.14 (lib)
Building     bifunctors-5.5.14 (lib)
Installing   bifunctors-5.5.14 (lib)
Completed    bifunctors-5.5.14 (lib)
Starting     assoc-1.0.2 (lib)
Starting     semigroupoids-5.3.7 (lib)
Building     assoc-1.0.2 (lib)
Building     semigroupoids-5.3.7 (lib)
Installing   assoc-1.0.2 (lib)
Completed    assoc-1.0.2 (lib)
Starting     these-1.1.1.1 (lib)
Building     these-1.1.1.1 (lib)
Installing   these-1.1.1.1 (lib)
Completed    these-1.1.1.1 (lib)
Starting     strict-0.4.0.1 (lib)
Building     strict-0.4.0.1 (lib)
Installing   semigroupoids-5.3.7 (lib)
Completed    semigroupoids-5.3.7 (lib)
Starting     semialign-1.2.0.1 (lib)
Building     semialign-1.2.0.1 (lib)
Installing   strict-0.4.0.1 (lib)
Completed    strict-0.4.0.1 (lib)
Installing   semialign-1.2.0.1 (lib)
Completed    semialign-1.2.0.1 (lib)
Starting     aeson-2.1.1.0 (lib)
Building     aeson-2.1.1.0 (lib)
           Installing   aeson-2.1.1.0 (lib)
Completed    aeson-2.1.1.0 (lib)
Configuring library for country-0.2.3.1..
Preprocessing library for country-0.2.3.1..
Building library for country-0.2.3.1..
[ 1 of 15] Compiling Continent.Unsafe ( src/Continent/Unsafe.hs, /home/chessai/haskell/country/dist-newstyle/build/x86_64-linux/ghc-9.4.4/country-0.2.3.1/build/Continent/Unsafe.o, /home/chessai/haskell/country/dist-newstyle/build/x86_64-linux/ghc-9.4.4/country-0.2.3.1/build/Continent/Unsafe.dyn_o )
[ 2 of 15] Compiling Country.Unexposed.Alias ( src/Country/Unexposed/Alias.hs, /home/chessai/haskell/country/dist-newstyle/build/x86_64-linux/ghc-9.4.4/country-0.2.3.1/build/Country/Unexposed/Alias.o, /home/chessai/haskell/country/dist-newstyle/build/x86_64-linux/ghc-9.4.4/country-0.2.3.1/build/Country/Unexposed/Alias.dyn_o )
[ 3 of 15] Compiling Country.Unexposed.AlphaTwoPtr ( src/Country/Unexposed/AlphaTwoPtr.hs, /home/chessai/haskell/country/dist-newstyle/build/x86_64-linux/ghc-9.4.4/country-0.2.3.1/build/Country/Unexposed/AlphaTwoPtr.o, /home/chessai/haskell/country/dist-newstyle/build/x86_64-linux/ghc-9.4.4/country-0.2.3.1/build/Country/Unexposed/AlphaTwoPtr.dyn_o )
[ 4 of 15] Compiling Country.Unexposed.Continents ( src/Country/Unexposed/Continents.hs, /home/chessai/haskell/country/dist-newstyle/build/x86_64-linux/ghc-9.4.4/country-0.2.3.1/build/Country/Unexposed/Continents.o, /home/chessai/haskell/country/dist-newstyle/build/x86_64-linux/ghc-9.4.4/country-0.2.3.1/build/Country/Unexposed/Continents.dyn_o )
[ 5 of 15] Compiling Country.Unexposed.Encode.English ( src/Country/Unexposed/Encode/English.hs, /home/chessai/haskell/country/dist-newstyle/build/x86_64-linux/ghc-9.4.4/country-0.2.3.1/build/Country/Unexposed/Encode/English.o, /home/chessai/haskell/country/dist-newstyle/build/x86_64-linux/ghc-9.4.4/country-0.2.3.1/build/Country/Unexposed/Encode/English.dyn_o )
[ 6 of 15] Compiling Country.Unexposed.Names ( src/Country/Unexposed/Names.hs, /home/chessai/haskell/country/dist-newstyle/build/x86_64-linux/ghc-9.4.4/country-0.2.3.1/build/Country/Unexposed/Names.o, /home/chessai/haskell/country/dist-newstyle/build/x86_64-linux/ghc-9.4.4/country-0.2.3.1/build/Country/Unexposed/Names.dyn_o )

src/Country/Unexposed/Names.hs:35:1: warning: [-Wunused-imports]
    The import of ‘Data.Bytes.Types’ is redundant
      except perhaps to import instances from ‘Data.Bytes.Types’
    To import instances alone, use: import Data.Bytes.Types()
   |
35 | import Data.Bytes.Types (Bytes(Bytes))
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Country/Unexposed/Names.hs:62:1: warning: [-Wunused-imports]
    The qualified import of ‘Data.Text.Array’ is redundant
      except perhaps to import instances from ‘Data.Text.Array’
    To import instances alone, use: import Data.Text.Array()
   |
62 | import qualified Data.Text.Array as Text
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Country/Unexposed/Names.hs:63:1: warning: [-Wunused-imports]
    The qualified import of ‘Data.Text.Internal’ is redundant
      except perhaps to import instances from ‘Data.Text.Internal’
    To import instances alone, use: import Data.Text.Internal()
   |
63 | import qualified Data.Text.Internal as Text
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[ 7 of 15] Compiling Country.Unexposed.Subdivision ( src/Country/Unexposed/Subdivision.hs, /home/chessai/haskell/country/dist-newstyle/build/x86_64-linux/ghc-9.4.4/country-0.2.3.1/build/Country/Unexposed/Subdivision.o, /home/chessai/haskell/country/dist-newstyle/build/x86_64-linux/ghc-9.4.4/country-0.2.3.1/build/Country/Unexposed/Subdivision.dyn_o )
[ 8 of 15] Compiling Country.Subdivision ( src/Country/Subdivision.hs, /home/chessai/haskell/country/dist-newstyle/build/x86_64-linux/ghc-9.4.4/country-0.2.3.1/build/Country/Subdivision.o, /home/chessai/haskell/country/dist-newstyle/build/x86_64-linux/ghc-9.4.4/country-0.2.3.1/build/Country/Subdivision.dyn_o )
[ 9 of 15] Compiling Country.Unexposed.Trie ( src/Country/Unexposed/Trie.hs, /home/chessai/haskell/country/dist-newstyle/build/x86_64-linux/ghc-9.4.4/country-0.2.3.1/build/Country/Unexposed/Trie.o, /home/chessai/haskell/country/dist-newstyle/build/x86_64-linux/ghc-9.4.4/country-0.2.3.1/build/Country/Unexposed/Trie.dyn_o )

src/Country/Unexposed/Trie.hs:10:1: warning: [-Wunused-imports]
    The import of ‘Data.Semigroup’ is redundant
      except perhaps to import instances from ‘Data.Semigroup’
    To import instances alone, use: import Data.Semigroup()
   |
10 | import Data.Semigroup (Semigroup)
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Country/Unexposed/Trie.hs:21:5: warning: [-Wunused-top-binds]
    Defined but not used: ‘trieValue’
   |
21 |   { trieValue :: {-# UNPACK #-} !Word16
   |     ^^^^^^^^^

src/Country/Unexposed/Trie.hs:22:5: warning: [-Wunused-top-binds]
    Defined but not used: ‘trieChildren’
   |
22 |   , trieChildren :: !(HashMap Char Trie)
   |     ^^^^^^^^^^^^
[10 of 15] Compiling Country.Unexposed.TrieByte ( src/Country/Unexposed/TrieByte.hs, /home/chessai/haskell/country/dist-newstyle/build/x86_64-linux/ghc-9.4.4/country-0.2.3.1/build/Country/Unexposed/TrieByte.o, /home/chessai/haskell/country/dist-newstyle/build/x86_64-linux/ghc-9.4.4/country-0.2.3.1/build/Country/Unexposed/TrieByte.dyn_o )

src/Country/Unexposed/TrieByte.hs:10:1: warning: [-Wunused-imports]
    The import of ‘Data.Semigroup’ is redundant
      except perhaps to import instances from ‘Data.Semigroup’
    To import instances alone, use: import Data.Semigroup()
   |
10 | import Data.Semigroup (Semigroup)
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Country/Unexposed/TrieByte.hs:21:5: warning: [-Wunused-top-binds]
    Defined but not used: ‘trieValue’
   |
21 |   { trieValue :: {-# UNPACK #-} !Word16
   |     ^^^^^^^^^

src/Country/Unexposed/TrieByte.hs:22:5: warning: [-Wunused-top-binds]
    Defined but not used: ‘trieChildren’
   |
22 |   , trieChildren :: !(HashMap Word8 TrieByte)
   |     ^^^^^^^^^^^^
[11 of 15] Compiling Country.Unexposed.Util ( src/Country/Unexposed/Util.hs, /home/chessai/haskell/country/dist-newstyle/build/x86_64-linux/ghc-9.4.4/country-0.2.3.1/build/Country/Unexposed/Util.o, /home/chessai/haskell/country/dist-newstyle/build/x86_64-linux/ghc-9.4.4/country-0.2.3.1/build/Country/Unexposed/Util.dyn_o )
[12 of 15] Compiling Country.Unsafe   ( src/Country/Unsafe.hs, /home/chessai/haskell/country/dist-newstyle/build/x86_64-linux/ghc-9.4.4/country-0.2.3.1/build/Country/Unsafe.o, /home/chessai/haskell/country/dist-newstyle/build/x86_64-linux/ghc-9.4.4/country-0.2.3.1/build/Country/Unsafe.dyn_o )
[13 of 15] Compiling Country.Identifier ( src/Country/Identifier.hs, /home/chessai/haskell/country/dist-newstyle/build/x86_64-linux/ghc-9.4.4/country-0.2.3.1/build/Country/Identifier.o, /home/chessai/haskell/country/dist-newstyle/build/x86_64-linux/ghc-9.4.4/country-0.2.3.1/build/Country/Identifier.dyn_o )
[14 of 15] Compiling Country          ( src/Country.hs, /home/chessai/haskell/country/dist-newstyle/build/x86_64-linux/ghc-9.4.4/country-0.2.3.1/build/Country.o, /home/chessai/haskell/country/dist-newstyle/build/x86_64-linux/ghc-9.4.4/country-0.2.3.1/build/Country.dyn_o )
[15 of 15] Compiling Continent        ( src/Continent.hs, /home/chessai/haskell/country/dist-newstyle/build/x86_64-linux/ghc-9.4.4/country-0.2.3.1/build/Continent.o, /home/chessai/haskell/country/dist-newstyle/build/x86_64-linux/ghc-9.4.4/country-0.2.3.1/build/Continent.dyn_o )
```